### PR TITLE
Fixed startup error in `loadGroups`

### DIFF
--- a/src/main/java/net/thenextlvl/perworlds/PerWorldsPlugin.java
+++ b/src/main/java/net/thenextlvl/perworlds/PerWorldsPlugin.java
@@ -100,6 +100,7 @@ public class PerWorldsPlugin extends JavaPlugin {
 
     private void loadGroups() {
         var suffix = ".dat";
+        if (!Files.exists(provider.getDataFolder())) return;
         try (var files = Files.list(provider.getDataFolder())) {
             files.map(path -> path.getFileName().toString())
                     .filter(name -> name.endsWith(suffix))


### PR DESCRIPTION
Added a check to prevent harmless error when no groups folder exists during first startup.