### PR TITLE
Add overloaded `createGroup` methods

### DIFF
--- a/api/src/main/java/net/thenextlvl/perworlds/GroupProvider.java
+++ b/api/src/main/java/net/thenextlvl/perworlds/GroupProvider.java
@@ -126,7 +126,7 @@ public interface GroupProvider {
      *
      * @param name   the name of the group to be created.
      * @param data   a {@link Consumer} to configure the {@link GroupData} for the new group.
-     * @param worlds an collection of {@link World} instances that will be part of the group.
+     * @param worlds a collection of {@link World} instances that will be part of the group.
      * @return the created {@link WorldGroup} instance.
      * @throws IllegalStateException if a group with the specified name already exists,
      *                               or if a given world is already part of another group.

--- a/api/src/main/java/net/thenextlvl/perworlds/GroupProvider.java
+++ b/api/src/main/java/net/thenextlvl/perworlds/GroupProvider.java
@@ -116,6 +116,7 @@ public interface GroupProvider {
      * @return the created {@link WorldGroup} instance.
      * @throws IllegalStateException if a group with the specified name already exists,
      *                               or if a given world is already part of another group.
+     * @since 1.0.2
      */
     @Contract(value = "_, _, _ -> new", mutates = "this")
     WorldGroup createGroup(String name, Consumer<GroupData> data, World... worlds) throws IllegalStateException;
@@ -130,6 +131,7 @@ public interface GroupProvider {
      * @return the created {@link WorldGroup} instance.
      * @throws IllegalStateException if a group with the specified name already exists,
      *                               or if a given world is already part of another group.
+     * @since 1.0.2
      */
     @Contract(value = "_, _, _ -> new", mutates = "this")
     WorldGroup createGroup(String name, Consumer<GroupData> data, Collection<World> worlds) throws IllegalStateException;

--- a/api/src/main/java/net/thenextlvl/perworlds/GroupProvider.java
+++ b/api/src/main/java/net/thenextlvl/perworlds/GroupProvider.java
@@ -107,6 +107,34 @@ public interface GroupProvider {
     WorldGroup createGroup(String name, Collection<World> worlds) throws IllegalStateException;
 
     /**
+     * Creates a new {@link WorldGroup} with the specified name, data, and a collection of worlds.
+     * The group must have a unique name and cannot conflict with already existing groups.
+     *
+     * @param name   the name of the group to be created.
+     * @param data   a {@link Consumer} to configure the {@link GroupData} for the new group.
+     * @param worlds an array of {@link World} instances that will be part of the group.
+     * @return the created {@link WorldGroup} instance.
+     * @throws IllegalStateException if a group with the specified name already exists,
+     *                               or if a given world is already part of another group.
+     */
+    @Contract(value = "_, _, _ -> new", mutates = "this")
+    WorldGroup createGroup(String name, Consumer<GroupData> data, World... worlds) throws IllegalStateException;
+
+    /**
+     * Creates a new {@link WorldGroup} with the specified name, data, and a collection of worlds.
+     * The group must have a unique name and cannot conflict with already existing groups.
+     *
+     * @param name   the name of the group to be created.
+     * @param data   a {@link Consumer} to configure the {@link GroupData} for the new group.
+     * @param worlds an collection of {@link World} instances that will be part of the group.
+     * @return the created {@link WorldGroup} instance.
+     * @throws IllegalStateException if a group with the specified name already exists,
+     *                               or if a given world is already part of another group.
+     */
+    @Contract(value = "_, _, _ -> new", mutates = "this")
+    WorldGroup createGroup(String name, Consumer<GroupData> data, Collection<World> worlds) throws IllegalStateException;
+
+    /**
      * Creates a new {@link WorldGroup} with the specified name, data, settings, and a collection of worlds.
      * The group must have a unique name and cannot conflict with already existing groups.
      *

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.compileJava {
 }
 
 group = "net.thenextlvl.perworlds"
-version = "1.0.1"
+version = "1.0.2"
 
 repositories {
     mavenCentral()

--- a/src/main/java/net/thenextlvl/perworlds/group/PaperGroupProvider.java
+++ b/src/main/java/net/thenextlvl/perworlds/group/PaperGroupProvider.java
@@ -184,7 +184,6 @@ public class PaperGroupProvider implements GroupProvider {
     @Override
     public WorldGroup createGroup(String name, Collection<World> worlds) throws IllegalStateException {
         return createGroup(name, data -> {
-        }, settings -> {
         }, worlds);
     }
 
@@ -208,7 +207,6 @@ public class PaperGroupProvider implements GroupProvider {
     @Override
     public WorldGroup createGroup(String name, World... worlds) throws IllegalStateException {
         return createGroup(name, data -> {
-        }, settings -> {
         }, worlds);
     }
 

--- a/src/main/java/net/thenextlvl/perworlds/group/PaperGroupProvider.java
+++ b/src/main/java/net/thenextlvl/perworlds/group/PaperGroupProvider.java
@@ -189,6 +189,18 @@ public class PaperGroupProvider implements GroupProvider {
     }
 
     @Override
+    public WorldGroup createGroup(String name, Consumer<GroupData> data, World... worlds) throws IllegalStateException {
+        return createGroup(name, data, settings -> {
+        }, worlds);
+    }
+
+    @Override
+    public WorldGroup createGroup(String name, Consumer<GroupData> data, Collection<World> worlds) throws IllegalStateException {
+        return createGroup(name, data, settings -> {
+        }, worlds);
+    }
+
+    @Override
     public WorldGroup createGroup(String name, Consumer<GroupData> data, Consumer<GroupSettings> settings, World... worlds) {
         return createGroup(name, data, settings, List.of(worlds));
     }


### PR DESCRIPTION
Introduced overloads for `createGroup` to support flexible configurations using varargs or collections of worlds. Improved Javadocs to document new methods comprehensively.