### PR TITLE
Handle null world in respawn data loading

### DIFF
--- a/src/main/java/net/thenextlvl/perworlds/listener/RespawnListener.java
+++ b/src/main/java/net/thenextlvl/perworlds/listener/RespawnListener.java
@@ -67,8 +67,8 @@ public final class RespawnListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerPostRespawn(PlayerPostRespawnEvent event) {
-        provider.getGroup(event.getRespawnedLocation().getWorld())
-                .orElse(provider.getUnownedWorldGroup())
-                .loadPlayerData(event.getPlayer(), false);
+        var location = event.getRespawnLocation();
+        var world = location.getWorld() != null ? location.getWorld() : event.getPlayer().getWorld();
+        provider.getGroup(world).orElse(provider.getUnownedWorldGroup()).loadPlayerData(event.getPlayer(), false);
     }
 }


### PR DESCRIPTION
- Default to player's current world if respawn world is null
- Ensure player data loads correctly after respawn

_This is a bug introduced by Paper :)_